### PR TITLE
docs: Add SECURITY.md policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,27 @@
+# # Security Policy
+
+The `stasis` project takes all security vulnerabilities seriously. Thank you for your efforts to improve its security. Your efforts to disclose your findings responsibly are greatly appreciated.
+
+## Reporting a Vulnerability
+
+`stasis` uses GitHub's **Private Vulnerability Reporting** feature to manage and resolve security issues. This ensures that your findings are received by the maintainer directly and are not publicly disclosed until a patch is available.
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+To report a vulnerability, please follow these steps:
+
+1. Navigate to the [Security tab of the `stasis` repository](https://github.com/daemoninstitute/stasis/security).
+2. Click on the "Report a vulnerability" button.
+3. Fill out the form with as much detail as possible, including:
+   * A clear description of the vulnerability.
+   * Steps to reproduce the issue.
+   * The potential impact of the vulnerability.
+   * Any suggested mitigations or patches, if available.
+
+## Scope
+
+This policy applies to the `stasis` project and its core source code. Please report vulnerabilities only in the code maintained within this repository.
+
+---
+
+The project maintainer is committed to working with you to understand and resolve the issue in a timely manner. 


### PR DESCRIPTION
### Description

Adds the official `SECURITY.md` file to direct security researchers to the private vulnerability reporting channel, as per best practices.

### Checklist

- [x] I have read the [**CONTRIBUTING.md**](https://github.com/daemoninstitute/stasis/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have signed all my commits to comply with the DCO (see CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the necessary documentation (if appropriate).
- [ ] I have run the full test suite locally and all tests pass.
