### PR TITLE
docs: Add SECURITY.md policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,4 +1,4 @@
-# # Security Policy
+# Security Policy
 
 The `stasis` project takes all security vulnerabilities seriously. Thank you for your efforts to improve its security. Your efforts to disclose your findings responsibly are greatly appreciated.
 


### PR DESCRIPTION
### Description

Adds the official `SECURITY.md` file to direct security researchers to the private vulnerability reporting channel, as per best practices.

### Checklist

- [x] I have read the [**CONTRIBUTING.md**](https://github.com/daemoninstitute/stasis/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have signed all my commits to comply with the DCO (see CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the necessary documentation (if appropriate).
- [ ] I have run the full test suite locally and all tests pass.
