### PR TITLE
perf: commit move semantics

### DIFF
--- a/include/stasis/stasis.hpp
+++ b/include/stasis/stasis.hpp
@@ -80,9 +80,10 @@ public:
     transactions_.pop_back();
 
     if (transactions_.empty()) {
-      apply_changes_to_store(main_store_, committed_tx);
+      apply_changes_to_store(main_store_, std::move(committed_tx));
     } else {
-      apply_changes_to_transaction(transactions_.back(), committed_tx);
+      apply_changes_to_transaction(transactions_.back(),
+                                   std::move(committed_tx));
     }
 
     return Success{};
@@ -167,10 +168,10 @@ private:
   }
 
   static void apply_changes_to_store(MainStore &store,
-                                     const TransactionChanges &changes) {
-    for (const auto &[key, value_opt] : changes) {
+                                     TransactionChanges changes) {
+    for (auto &&[key, value_opt] : changes) {
       if (value_opt.has_value()) {
-        store.insert_or_assign(key, *value_opt);
+        store.insert_or_assign(key, std::move(*value_opt));
       } else {
         store.erase(key);
       }
@@ -178,9 +179,9 @@ private:
   }
 
   static void apply_changes_to_transaction(TransactionChanges &parent_tx,
-                                           const TransactionChanges &child_tx) {
-    for (const auto &[key, value_opt] : child_tx) {
-      parent_tx.insert_or_assign(key, value_opt);
+                                           TransactionChanges child_tx) {
+    for (auto &&[key, value_opt] : child_tx) {
+      parent_tx.insert_or_assign(key, std::move(value_opt));
     }
   }
 


### PR DESCRIPTION
### Description

Modified the internal helper functions to take ownership of the transaction data, allowing the use of `std::move` instead of copying.

### Checklist

- [x] I have read the [**CONTRIBUTING.md**](https://github.com/daemoninstitute/stasis/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have signed all my commits to comply with the DCO (see CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the necessary documentation (if appropriate).
- [x] I have run the full test suite locally and all tests pass.
