### PR TITLE
refactor(kv): removed unused key_exists helper

### DIFF
--- a/include/stasis/stasis.hpp
+++ b/include/stasis/stasis.hpp
@@ -165,10 +165,6 @@ private:
     return std::unexpected(AppError::KeyNotFound);
   }
 
-  [[nodiscard]] auto key_exists(std::string_view key) const -> bool {
-    return get_value(key).has_value();
-  }
-
   static void apply_changes_to_store(MainStore &store,
                                      TransactionChanges changes) {
     for (auto &&[key, value_opt] : changes) {


### PR DESCRIPTION
### Description

This removes the private helper function `key_exists`, which was no longer being called anywhere in the class after a previous refactoring.

### Checklist

- [x] I have read the [**CONTRIBUTING.md**](https://github.com/daemoninstitute/stasis/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have signed all my commits to comply with the DCO (see CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the necessary documentation (if appropriate).
- [x] I have run the full test suite locally and all tests pass.
