### PR TITLE
fix(kv): use find-then-erase for allocation-free deletion

### DIFF
--- a/include/stasis/stasis.hpp
+++ b/include/stasis/stasis.hpp
@@ -136,7 +136,12 @@ public:
     }
 
     if (transactions_.empty()) {
-      main_store_.erase(std::string(key));
+      // transparent erase is not universally available
+      // find-then-erase pattern used in its place for allocation-free deletion
+      if (const auto iterator = main_store_.find(key);
+          iterator != main_store_.end()) {
+        main_store_.erase(iterator);
+      }
     } else {
       transactions_.back().insert_or_assign(std::string(key), std::nullopt);
     }


### PR DESCRIPTION
### Description

Replaced the allocation-heavy erase with a find-then-erase pattern, providing widely compatible allocation-free deletion.

### Checklist

- [x] I have read the [**CONTRIBUTING.md**](https://github.com/daemoninstitute/stasis/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have signed all my commits to comply with the DCO (see CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the necessary documentation (if appropriate).
- [x] I have run the full test suite locally and all tests pass.
